### PR TITLE
allow two string attributes

### DIFF
--- a/src/schema_lexer.xrl
+++ b/src/schema_lexer.xrl
@@ -8,7 +8,7 @@ WS              = [\s\t]+
 NL              = [\n\r]+
 COMMENT         = //[^\n\r]+
 BLOCK_COMMENT   = /\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*+/
-STRING_CONSTANT = \".*\"
+STRING_CONSTANT = \"[^"]*\"
 COLON           = \:
 
 Rules.

--- a/test/schemas/parser_attribute.fbs
+++ b/test/schemas/parser_attribute.fbs
@@ -1,5 +1,7 @@
 attribute "priority";
 attribute "name";
+attribute "more";
+attribute "flag";
 
 enum Color : byte (priority: 5) { Red, Green, Blue }
 union Animal (priority: 4) { Dog, Cat }
@@ -8,7 +10,7 @@ table Dog {
   age:int;
 }
 
-table Cat (name: "Meow:Purr") {
+table Cat (name: "Meow:Purr", flag) {
   lives:int;
 }
 
@@ -16,11 +18,11 @@ struct Nest (priority: 3) {
   shortNum:short;
 }
 
-table State (priority: 2, name: "Foo:Bar") {
+table State (priority: 2, name: "Foo:Bar", more: "Baz:zup") {
   active:bool = false (deprecated, priority: 1);
-  color:[Color] (priority: 6);
+  color:[Color] (priority: 6, name: "color");
   animal:Animal;
-  nest:Nest;
+  nest:Nest (priority: 9, more: "foo");
 }
 
 root_type State;


### PR DESCRIPTION
The `STRING_CONSTANT` token definition stops at the first terminating double. quote rather than consuming the entire line until the final terminating double quote.

Additionally, return field attributes as well as referenced type attributes on the decorated schema.